### PR TITLE
add reqs for Binder

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,12 @@
+numpy==1.14.2
+pandas==0.23.4
+keras==2.1.6
+theano==1.0.1
+scikit-learn==0.20.0
+joblib==0.12.4
+tqdm==4.24.0
+xgboost==0.7.post3
+matplotlib==2.1.0
+seaborn==0.8.0
+watermark==1.7.0
+tensorflow==1.12.0


### PR DESCRIPTION
Hi!

I was watching your #BioData18 talk and saw you have some notebooks in the repo. I added the requirements to be able to run the repo on Binder, here is an example with the PR branch: [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/luizirber/avocado/binder)

But I had an issue in the "Avocado Training Demo" notebook when creating the model:
```
TypeError: Value passed to parameter 'shape' has DataType float32 not in list of allowed values: int32, int64
```

I suspect it's because Binder doesn't have GPU access, and I used plain tensorflow in the requirements?