### PR TITLE
fix-variable-names

### DIFF
--- a/avocado/utils.py
+++ b/avocado/utils.py
@@ -52,9 +52,9 @@ def download_bigWig(url, download_filepath='.', chroms=chroms,
 
 		if chrom_lengths is not None:
 			if chrom != 'X':
-				data_ = numpy.zeros(chromosome_lengths[chrom-1])
+				data_ = numpy.zeros(chrom_lengths[chrom - 1])
 			else:
-				data_ = numpy.zeros(chromosome_lengths[-1])
+				data_ = numpy.zeros(chrom_lengths[-1])
 
 			data_[:len(data)] = data
 			data = data_
@@ -67,9 +67,9 @@ def download_bigWig(url, download_filepath='.', chroms=chroms,
 		os.system("rm {}".format(bedgraph))
 
 	if verbose == True:
-		print("rm {}".format(bigWig))
+		print("rm {}".format(bigwig))
 
-	os.system("rm {}".format(bigWig))
+	os.system("rm {}".format(bigwig))
 	return chrom_data
 
 def bedgraph_to_dense(filename, verbose=True):

--- a/avocado/utils.py
+++ b/avocado/utils.py
@@ -13,7 +13,8 @@ import os
 
 from tqdm import tqdm
 
-chroms = range(1, 23) + ['X']
+chroms = list(range(1, 23)) + ['X']
+
 
 def download_bigWig(url, download_filepath='.', chroms=chroms, 
 	chrom_lengths=None, verbose=True):


### PR DESCRIPTION
Hey @jmschrei thanks for sharing your code. It's interesting to look through.

A few things:

1. I noticed in the download bigWig util that `chromosome_lengths` variable doesn't exist. Is it supposed to be `chrom_lengths` instead? (By the way what is the purpose of decimating a vector and then assigning it back to a custom chrom_length? I'm assuming any passed in chrom_legnth will be much longer than the decimated vector.)

2. It looks like `bigWig` variable should be `bigwig` instead.

3. When I try to import this function I get following error: 

```python
(avo) kiene:avocado keenan$ python
Python 3.6.7 | packaged by conda-forge | (default, Feb 28 2019, 02:16:08) 
>>> from avocado.utils import download_bigWig
Using TensorFlow backend.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/keenan/Desktop/projects/github/avocado/avocado/utils.py", line 16, in <module>
    chroms = range(1, 23) + ['X']
TypeError: unsupported operand type(s) for +: 'range' and 'list'
```

This must by a Python 2 idiom, but based on the print statements it seems like Avocado should be run with Python 3? Changing code to `list(range(1, 23)) + ['X']` seems to solve this.

In any case not sure if it's useful to you but these changes appear to work for me: 

```python
(avo3) kiene:avocado keenan$ python
Python 3.6.7 | packaged by conda-forge | (default, Feb 28 2019, 02:16:08) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from avocado.utils import download_bigWig
Using TensorFlow backend.
>>> data = download_bigWig('https://www.encodeproject.org/files/ENCFF289XSX/@@download/ENCFF289XSX.bigWig')
wget -nv -q https://www.encodeproject.org/files/ENCFF289XSX/@@download/ENCFF289XSX.bigWig -P ./
2019-03-12 21:23:55 URL:https://encode-files.s3.amazonaws.com/2019/02/13/9a778a35-5a1a-4b1d-9207-bd2f09af2d07/ENCFF289XSX.bigWig?response-content-disposition=attachment%3B%20filename%3DENCFF289XSX.bigWig&Expires=1552580563&Signature=sD3BmCkh1%2FcYrfPAQC2xulzFyyU%3D&AWSAccessKeyId=ASIATGZNGCNX6HEOCSVV&x-amz-security-token=FQoGZXIvYXdzEBUaDLP8pWCUg42a5OTyKyK3A23C%2B%2B0XcTYGOyH96liuoZiqQVmx280j8Vyc4YsPlBJGprrjtuaJ9HvNWjIN3JpPYoaPJOFVa6XpBTyfhzur8ZNGIwORUQc8o4LszZM8E55YyDxTmXholVFgzowmJfsRBvn6IYJuI5cZojEBXI7g7QuqAapmOkSUfLPPPsRTnkQFnPfpukSEupVDJ4NkT2CxgJn%2B5UzH20DYSGZ65F3GYF1%2BNHC5SJMrkdY0Pwj7MLbbKpYRnoF1%2B9eA7iiMzf%2BZhJPuIAXjIfv0jpDelRF2OIljzasGJo5QM2bd2MBDN54yt%2BKEmonVrPzqbSzACUlbYOiAs4WWsT7EMLiWF1kGV6FHFk5IJZDItH2PZEUqULx1inu%2FzTHk%2B6oO0q7CqYnjQg6DmR70KkT7VO9dqGvjWJBP7OdTTnWhbTIVt5fJGNx5CEnvypPjelylsbDzwtGyewmYh3v4H53ZcdK1s3d7FW5I61cNHsEhXdD%2BD%2BKq6EqdhecyceJ5cgfVmoscQNSP83y%2BYePmfcnY6av2XDgF3Mp9bxp9OZrpsTtJSvHGQoF6HmCC7tDB6G73XVxe3qCT6bFv1ZnqJ6Ao6uuh5AU%3D [577542827/577542827] -> "./ENCFF289XSX.bigWig" [1]
bigWigToBedGraph ./ENCFF289XSX.bigWig ENCFF289XSX.chr1.bedgraph -chrom=chr1
bedgraph_to_dense(ENCFF289XSX.chr1.bedgraph)
100%|█████████████████████████████████████████████████████████████████████████████████████████| 8502512/8502512 [13:53<00:00, 10201.60it/s]
decimate_vector
rm ENCFF289XSX.chr1.bedgraph
rm ./ENCFF289XSX.bigWig
>>> len(data[0])
9957851
```

Thanks!
